### PR TITLE
Add header components for blog and projects

### DIFF
--- a/src/components/BlogPostHeader.astro
+++ b/src/components/BlogPostHeader.astro
@@ -1,0 +1,50 @@
+---
+// Components
+import Hero from "../components/Hero.astro";
+
+// Utils
+import { formatDate } from "../js/utils";
+
+// Props
+const { title, author, categories, date, image } = Astro.props;
+---
+
+<header>
+  <Hero title={title} caption={author}>
+    <div class="blog--details-wrapper">
+      <div>
+        <div class="blog--category-wrapper">
+          {
+            categories.map((category) => (
+              <p class="blog--category">{category}</p>
+            ))
+          }
+        </div>
+      </div>
+      <p>Publicación: {formatDate(date)}</p>
+    </div>
+  </Hero>
+  <img src={image.src} alt={image.alt} />
+</header>
+
+<style>
+  .blog--category-wrapper {
+    display: flex;
+    gap: 1rem;
+  }
+
+  .blog--category {
+    background-color: var(--bkg);
+    padding: 4px 10px;
+    border: 2px solid var(--blue);
+    border-radius: 4px;
+  }
+
+  .blog--details-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+  }
+</style>

--- a/src/components/ProjectPostHeader.astro
+++ b/src/components/ProjectPostHeader.astro
@@ -1,0 +1,12 @@
+---
+// Components
+import Hero from "../components/Hero.astro";
+
+// Props
+const { title, author, image } = Astro.props;
+---
+
+<header>
+  <Hero title={title} caption={author} />
+  <img src={image.src} alt={image.alt} />
+</header>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -6,10 +6,11 @@ import "../styles/global.css";
 import MainLayout from "./MainLayout.astro";
 
 // Components
-import Hero from "../components/Hero.astro";
+// import Hero from "../components/Hero.astro";
+import BlogPostHeader from "../components/BlogPostHeader.astro";
 
 // Utils
-import { formatDate } from "../js/utils";
+// import { formatDate } from "../js/utils";
 
 // Props
 const { frontmatter } = Astro.props;
@@ -17,21 +18,7 @@ const { title, date, author, image, description, categories } = frontmatter;
 ---
 
 <MainLayout title="CEPRODIDE - Blog" content={description} style="main-blog">
-  <Hero title={title} caption={author}>
-    <div class="blog--details-wrapper">
-      <div>
-        <div class="blog--category-wrapper">
-          {
-            categories.map((category) => (
-              <p class="blog--category">{category}</p>
-            ))
-          }
-        </div>
-      </div>
-      <p>Publicación: {formatDate(date)}</p>
-    </div>
-  </Hero>
-  <img src={image.src} alt={image.alt} />
+  <BlogPostHeader {title} {author} {categories} {date} {image} />
   <div class="blog--content-container">
     <div class="blog--content">
       <slot />
@@ -51,27 +38,7 @@ const { title, date, author, image, description, categories } = frontmatter;
     gap: 1.5rem;
   }
 
-  .blog--category-wrapper {
-    display: flex;
-    gap: 1rem;
-  }
-
-  .blog--category {
-    background-color: var(--bkg);
-    padding: 4px 10px;
-    border: 2px solid var(--blue);
-    border-radius: 4px;
-  }
-
-  .blog--details-wrapper {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 2rem;
-  }
-
-  . @media screen and (min-width: 760px) {
+  @media screen and (min-width: 760px) {
     .blog--content-container {
       margin: 5rem auto;
     }

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -6,7 +6,7 @@ import "../styles/global.css";
 import MainLayout from "./MainLayout.astro";
 
 // Components
-import Hero from "../components/Hero.astro";
+import ProjectPostHeader from "../components/ProjectPostHeader.astro";
 
 // Props
 const { frontmatter } = Astro.props;
@@ -18,8 +18,7 @@ const { title, author, image, description } = frontmatter;
   content={description}
   style={"main-blog"}
 >
-  <Hero title={title} caption={author} />
-  <img src={image.src} alt={image.alt} />
+  <ProjectPostHeader {title} {author} {image} />
   <div class="project--content-container">
     <div class="project--content">
       <slot />


### PR DESCRIPTION
Individualize the logic and props for the headers of each Blog post and Project post. 
- To accomplish that goal, I created two new components that contain this information. This decluter the BlogLayout and ProjectLayout.